### PR TITLE
Prefix component name onto props interface

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "outFiles": ["${workspaceFolder}/out/**/*.js"],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "npm: compile"
         },
         {
             "name": "Extension Tests",
@@ -20,7 +20,7 @@
                 "--extensionTestsPath=${workspaceFolder}/out/integration-test/suite/index"
             ],
             "outFiles": ["${workspaceFolder}/out/integration-test/**/*.js"],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "npm: compile"
         }
     ]
 }

--- a/src/template/javascriptTemplate.ts
+++ b/src/template/javascriptTemplate.ts
@@ -40,7 +40,7 @@ import React from 'react';
 import ${name} from './${name}';
 
 describe('${name}', () => {
-    const defaultProps: Props = {};
+    const defaultProps = {};
 
     it('should render', () => {
         const props = {...defaultProps};

--- a/src/template/typescriptTemplate.ts
+++ b/src/template/typescriptTemplate.ts
@@ -2,9 +2,9 @@ import TemplateOptions, { TestLibrary } from './templateOptions';
 
 const typescriptComponentTemplate = ({ name }: TemplateOptions) => `import React from 'react';
 
-export interface Props {}
+export interface ${name}Props {}
 
-function ${name}({ }: Props) {
+function ${name}({ }: ${name}Props) {
     return <>${name}</>
 };
 
@@ -22,10 +22,10 @@ const reactTestingLibraryTemplate = ({ name, cleanup }: TemplateOptions) => `imp
     cleanup ? 'cleanup, ' : ''
 }render } from '@testing-library/react';
 import React from 'react';
-import ${name}, { Props } from './${name}';
+import ${name}, { ${name}Props } from './${name}';
 
 describe('${name}', () => {
-    ${cleanup ? 'afterEach(cleanup);\n\t' : ''}const defaultProps: Props = {};
+    ${cleanup ? 'afterEach(cleanup);\n\t' : ''}const defaultProps: ${name}Props = {};
 
     it('should render', () => {
         const props = {...defaultProps};
@@ -39,10 +39,10 @@ describe('${name}', () => {
 
 const enzymeTemplate = ({ name }: TemplateOptions) => `import { shallow } from 'enzyme';
 import React from 'react';
-import ${name}, { Props } from './${name}';
+import ${name}, { ${name}Props } from './${name}';
 
 describe('${name}', () => {
-    const defaultProps: Props = {};
+    const defaultProps: ${name}Props = {};
 
     it('should render', () => {
         const props = {...defaultProps};


### PR DESCRIPTION
Currently the generated props interface for typescript components is super generic. This PR updates code generation to prefix the component name to the props interface.

For example: When generating a Typescript component called `MyComponent`, `Props` becomes `MyComponentProps`

Fixes #1 